### PR TITLE
fixed borked javascript code in unminified javascript

### DIFF
--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -147,6 +147,7 @@ Backbone.GoogleMaps = (function(Backbone, _, $){
 			// Set InfoWindow template
 			this.template = this.template || this.options.template;
 
+		},
 
 		// Render
 		render: function() {
@@ -190,7 +191,7 @@ Backbone.GoogleMaps = (function(Backbone, _, $){
 	*/
 	GoogleMaps.MarkerView = GoogleMaps.MapView.extend({
 		// Set associated InfoWindow view
-		infoWindow: GoogleMaps.InfoWindow
+		infoWindow: GoogleMaps.InfoWindow,
 
 		constructor: function() {
 			GoogleMaps.MapView.prototype.constructor.apply(this, arguments);


### PR DESCRIPTION
The default simple.html example doesn't work with the unminified javascript--there were some missing syntactical elements.

I wasn't sure how you minified the javascript, so I left that untouched.
