### PR TITLE
Register as a browser global or an AMD module

### DIFF
--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -12,9 +12,7 @@
   }
   else {
     // Browser globals
-    root.Backbone.GoogleMaps = factory(root.Backbone,
-                                       root._,
-                                       root.jQuery || root.Zepto || root.ender);
+    factory(root.Backbone, root._, root.jQuery || root.Zepto || root.ender);
   }
 }(this, function(Backbone, _, $) {
 
@@ -399,6 +397,7 @@
   })
 
 
+  Backbone.GoogleMaps = GoogleMaps;
   return GoogleMaps;
 }));
 


### PR DESCRIPTION
This is in response to pull request #6. I believe this one will work better as it removes an extra set of arg passing in the globals case. This pattern was based on this general UMD pattern:

https://github.com/umdjs/umd/blob/master/amdWeb.js

@peterlong: if you want to confirm this works for you, that would be good. I tried this file in the example.html in this repo and it works fine for the browser globals case.
