### PR TITLE
Scope "Global" Events to Backbone.GoogleMaps

### DIFF
--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -43,7 +43,7 @@
       if(!this.get("selected")) {
         this.set("selected", true);
         this.trigger('selected', this);
-        Backbone.Events.trigger("location:selected", this);
+        GoogleMaps.trigger("location:selected", this);
       }
     },
 
@@ -51,7 +51,7 @@
       if(this.get("selected")) {
         this.set("selected", false);
         this.trigger("deselected", this);
-        Backbone.Events.trigger('location:deselected', this);
+        GoogleMaps.trigger('location:deselected', this);
       }
     },
 
@@ -86,7 +86,7 @@
 
       // Deselect other models on model select
       // ie. Only a single model can be selected in a collection
-      Backbone.Events.on("location:selected", function(selectedModel) {
+      GoogleMaps.on("location:selected", function(selectedModel) {
         this.each(function(model) {
           if(selectedModel.cid !== model.cid) { model.deselect(); }
         });
@@ -398,6 +398,8 @@
     }
   })
 
+  // GoogleMaps-scoped Event Bus
+  _.extend(GoogleMaps, Backbone.Events);
 
   Backbone.GoogleMaps = GoogleMaps;
   return GoogleMaps;


### PR DESCRIPTION
With the current implementation, events that are specific to selected/deselected locations are being put out into the Backbone.Events object, which means that this library is leaking a bit outside of its containment.

I've made the GoogleMaps object itself into an event bus and updated the global events to be scoped to just the library.
