### PR TITLE
Add Events and Normalize on-Prototype Event Callbacks

### DIFF
--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -134,8 +134,12 @@
     },
 
     render: function() {
-      if(this.beforeRender) { this.beforeRender(); }
+      this.trigger('before:render');
+      if(this.onBeforeRender) { this.onBeforeRender(); }
+      
       this.bindMapEvents();
+      
+      this.trigger('render');
       if(this.onRender) { this.onRender(); }
 
       return this;
@@ -144,10 +148,14 @@
     // Clean up view
     // Remove overlay from map and remove event listeners
     close: function() {
-      if(this.beforeClose) { this.beforeClose(); }
+      this.trigger('before:close');
+      if(this.onBeforeClose) { this.onBeforeClose(); }
+      
       google.maps.event.clearInstanceListeners(this.gOverlay);
       if(this.gOverlay.setMap) { this.gOverlay.setMap(null); }
       this.gOverlay = null;
+      
+      this.trigger('close');
       if(this.onClose) { this.onClose(); }
     }
   });
@@ -174,7 +182,9 @@
 
     // Render
     render: function() {
-      if(this.beforeRender) { this.beforeRender(); }
+      this.trigger('before:render');
+      if(this.onBeforeRender) { this.onBeforeRender(); }
+      
       GoogleMaps.MapView.prototype.render.apply(this, arguments);
 
       // Render element
@@ -189,6 +199,7 @@
       // Display InfoWindow on map
       this.gOverlay.open(this.map, this.marker);
 
+      this.trigger('render');
       if(this.onRender) { this.onRender(); }
 
       return this;
@@ -196,10 +207,12 @@
 
     // Close and delete window, and clean up view
     close: function() {
-      if(this.beforeClose) { this.beforeClose(); }
+      this.trigger('before:close');
+      if(this.onBeforeClose) { this.onBeforeClose(); }
 
       GoogleMaps.MapView.prototype.close.apply(this, arguments);
 
+      this.trigger('close');
       if(this.onClose) { this.onClose(); }
 
       return this;
@@ -281,22 +294,27 @@
 
     // Show the google maps marker overlay
     render: function() {
-      if(this.beforeRender) { this.beforeRender(); }
+      this.trigger('before:render');
+      if(this.onBeforeRender) { this.onBeforeRender(); }
 
       GoogleMaps.MapView.prototype.render.apply(this, arguments);
       this.gOverlay.setVisible(true);
 
+      this.trigger('render');
       if(this.onRender) { this.onRender(); }
 
       return this;
     },
 
     close: function() {
-      if(this.beforeClose) { this.beforeClose(); }
+      this.trigger('before:close');
+      if(this.onBeforeClose) { this.onBeforeClose(); }
+      
       this.closeDetail();
       GoogleMaps.MapView.prototype.close.apply(this, arguments);
       this.model.off();
 
+      this.trigger('close');
       if(this.onClose) { this.onClose() }
 
       return this;
@@ -349,11 +367,13 @@
     render: function(collection) {
       var collection = collection || this.collection;
 
-      if(this.beforeRender) { this.beforeRender(); }
+      this.trigger('before:render');
+      if(this.onBeforeRender) { this.onBeforeRender(); }
 
       // Create marker views for each model
       collection.each(this.addChild);
 
+      this.trigger('render');
       if(this.onRender) { this.onRender(); }
 
       return this;


### PR DESCRIPTION
Hi again,

I normalized all of the event callbacks that exist directly on an object. It seems that most plug-ins have standardized on "onEventName" as the callback name pattern. The "before" events were all missing the "on" part.

I also updated your views to trigger full events on at those points in time, so multiple interested parties can be notified when something renders or closes.

Cheers,
Michael
