### PR TITLE
Enable MarkerViewCollection constructor to accept marker overlayOptions

### DIFF
--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -462,7 +462,8 @@
     addChild: function(childModel) {
       var markerView = new this.markerView({
         model: childModel,
-        map: this.map
+        map: this.map,
+        overlayOptions: this.options.overlayOptions || {}
       });
 
       this.markerViewChildren[childModel.cid] = markerView;


### PR DESCRIPTION
With the change the client will be able to pass an object in the MarkerViewCollection constructor
that will contain the overlay options for each marker in this collection.

I also haven't minified this.
Wouldn't it be better if the minified version was only provided in the releases section?
