### PR TITLE
Add support for javascript inline template for infoWindow

### DIFF
--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -215,6 +215,10 @@
       // Set InfoWindow template
       this.template = this.template || this.options.template;
 
+      // Set InfoWindow template directly via HTML
+      this.templateHtml = this.templateHtml || this.options.templateHtml;
+
+
     },
 
     // Render
@@ -227,7 +231,11 @@
       GoogleMaps.MapView.prototype.render.apply(this, arguments);
 
       // Render element
-      var tmpl = (this.template) ? $(this.template).html() : '<h2><%=title %></h2>';
+      var tmpl = (this.templateHtml)
+            ? this.templateHtml
+            : (this.template) 
+                ? $(this.template).html()
+                : '<h2><%=title %></h2>';
       this.$el.html(_.template(tmpl, this.model.toJSON()));
 
       // Create InfoWindow
@@ -485,4 +493,3 @@
   Backbone.GoogleMaps = GoogleMaps;
   return GoogleMaps;
 }));
-

--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -233,10 +233,10 @@
       // Render element
       var tmpl = (this.templateHtml)
             ? this.templateHtml
-            : (this.template) 
+            : (this.template)
                 ? $(this.template).html()
                 : '<h2><%=title %></h2>';
-      this.$el.html(_.template(tmpl, this.model.toJSON()));
+      this.$el.html(_.template(tmpl)(this.model.toJSON()));
 
       // Create InfoWindow
       this.gOverlay = new google.maps.InfoWindow(_.extend({

--- a/lib/backbone.googlemaps.js
+++ b/lib/backbone.googlemaps.js
@@ -215,10 +215,6 @@
       // Set InfoWindow template
       this.template = this.template || this.options.template;
 
-      // Set InfoWindow template directly via HTML
-      this.templateHtml = this.templateHtml || this.options.templateHtml;
-
-
     },
 
     // Render
@@ -231,12 +227,20 @@
       GoogleMaps.MapView.prototype.render.apply(this, arguments);
 
       // Render element
-      var tmpl = (this.templateHtml)
-            ? this.templateHtml
-            : (this.template)
-                ? $(this.template).html()
-                : '<h2><%=title %></h2>';
-      this.$el.html(_.template(tmpl)(this.model.toJSON()));
+      var tmpl = function(model) {
+        return _.template('<h2><%=title %></h2>')(model.toJSON());
+      }
+
+      if (this.template) {
+        if (_.isFunction(this.template)) {
+          tmpl = this.template;
+        } else if (_.isString(this.template)) {
+          tmpl = function(model) {
+            _.template($(this.template).html())(model.toJSON());
+          }
+        }
+      }
+      this.$el.html(tmpl.call(this,this.model));
 
       // Create InfoWindow
       this.gOverlay = new google.maps.InfoWindow(_.extend({


### PR DESCRIPTION
Mojolicious uses it’s own embeded Perl parser and the embeded variables look something like this:

<%= $var %>

Underscore uses this as their embeded vars:

<%= var %>

So unless we use a different template engine, we cannot place these underscore templates inline with mojolicious templates because it will try to parse the Javascript template.

So I added a templateHtml to directly set html template in InfoWindow without use of a DOM template in the html file.